### PR TITLE
add a new field configuration_source to tag this module

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -1,6 +1,7 @@
 provider "alicloud" {
-  version    = ">=1.53.0"
-  access_key = var.ali_access_key
-  secret_key = var.ali_secret_key
-  region     = var.ali_region
+  version              = ">=1.56.0"
+  access_key           = var.ali_access_key
+  secret_key           = var.ali_secret_key
+  region               = var.ali_region
+  configuration_source = "hajowieland/k8s"
 }


### PR DESCRIPTION
Hi I am from alibaba cloud and I am working on terraform-provider-alicloud. The provider 1.56.0 has provide a new field `configuration_source` to supported mark one configuration or module. This tag can help you to know how many developers are using it.